### PR TITLE
Fix issue with webcam uploads

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,13 @@ module.exports = class ActiveStorageUpload extends Plugin {
         request.upload.addEventListener("progress", event => directHandlers.directUploadDidProgress(event))
       }
 
-      const upload = new DirectUpload(file.data, this.opts.directUploadUrl, directHandlers);
+      const { data, meta } = file;
+
+      if(!data.name && meta.name) {
+        data.name = meta.name
+      }
+
+      const upload = new DirectUpload(data, this.opts.directUploadUrl, directHandlers);
       const id = cuid();
 
       upload.create((error, blob) => {


### PR DESCRIPTION
Hey, so I'm using uppy with dashboard + webcam plugin along with this plugin. When attempting to take a picture with the webcam active storage fails to save as its expecting a filename. 

Webcam images do not return the filename on the data object but are provided in the meta object. This simply copies that over if available.